### PR TITLE
Implement configurable training and trading utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from src.auth.fyers_auth import AuthCodeGenerator
 from src.data.data_fetcher import DataHandler
 from src.utils.utils import load_symbols
+import pandas as pd
 from typing import Callable
 from src.feature_engineering.technical_indicators import TechnicalIndicators
 from src.financial_analysis.trading_strategies import TradingStrategies
@@ -108,17 +109,27 @@ class MarketAnalysisApp:
         pass
 
     def start_backtesting(self):
-        ## TODO fill backtest logic
-        for symbol in config.symbols:
-            data_agg = self.data_aggregator.aggregate_features(
-                self.ticker_data_handler.data[symbol], self.order_data_handler.data[symbol])
-            
-            ## Run Custom pipeline
-            self.custom_model.run(data_agg)
-            
-            
-            
-        pass
+        """Run backtesting for all configured symbols."""
+        if getattr(config.training, 'combine_all_symbols', False):
+            combined = []
+            for symbol in config.symbols:
+                data_agg = self.data_aggregator.aggregate_features(
+                    self.ticker_data_handler.data[symbol],
+                    self.order_data_handler.data[symbol]
+                )
+                data_agg['symbol'] = symbol
+                combined.append(data_agg)
+
+            if combined:
+                combined_df = pd.concat(combined, ignore_index=True)
+                self.custom_model.train(combined_df, 'ALL_SYMBOLS')
+        else:
+            for symbol in config.symbols:
+                data_agg = self.data_aggregator.aggregate_features(
+                    self.ticker_data_handler.data[symbol],
+                    self.order_data_handler.data[symbol]
+                )
+                self.custom_model.train(data_agg, symbol)
     
     def _setup_authorization(self):
         """

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -5,6 +5,7 @@ defaults:
   - model/pipeline_config
   - paths                  # Loads paths directly
   - custom
+  - trading
   - symbols
   - columns/common_column_defs    # Loads common_column_defs for shared column names
   - columns/numerical_columns

--- a/src/config/custom.yaml
+++ b/src/config/custom.yaml
@@ -29,8 +29,13 @@ model_settings:
   model_type: COMB
   shuffle: true
   run_ids:
-   - 5min
-   - 15min
-   - 30min
-   - 1h
-   - 3h
+    - 5min
+    - 15min
+    - 30min
+    - 1h
+    - 3h
+
+# New setting to control whether training combines
+# data across all symbols or trains models per symbol.
+training:
+  combine_all_symbols: false

--- a/src/config/trading.yaml
+++ b/src/config/trading.yaml
@@ -1,0 +1,3 @@
+trading_decision:
+  buy_labels: ["High", "Medium High"]
+  sell_labels: ["Medium Low", "Low"]

--- a/src/trading_logic/fyers_trade_executor.py
+++ b/src/trading_logic/fyers_trade_executor.py
@@ -1,0 +1,31 @@
+"""Fyers trading execution module."""
+from typing import Optional
+from loguru import logger
+from fyers_apiv3 import fyersModel
+
+class FyersTradeExecutor:
+    """Execute trades using the Fyers API."""
+
+    def __init__(self, fyers: fyersModel) -> None:
+        self.fyers = fyers
+
+    def place_order(self, symbol: str, qty: int, side: str, price: Optional[float] = None) -> None:
+        """Place a market order via the Fyers API."""
+        try:
+            order = {
+                "symbol": symbol,
+                "qty": qty,
+                "type": 2,  # Market order
+                "side": 1 if side == "BUY" else -1,
+                "productType": "INTRADAY",
+                "limitPrice": price or 0,
+                "stopPrice": 0,
+                "validity": "DAY",
+                "disclosedQty": 0,
+                "offlineOrder": False,
+                "orderTag": "codex",
+            }
+            self.fyers.place_order(order)
+            logger.info("Placed %s order for %s qty %d", side, symbol, qty)
+        except Exception as exc:
+            logger.error("Failed to place order: %s", exc)

--- a/src/trading_logic/trade_execution_manager.py
+++ b/src/trading_logic/trade_execution_manager.py
@@ -9,6 +9,7 @@ import pandas as pd
 from src.utils.utils import load_symbols
 from src.trading_logic.strategy_manager import StrategyManager
 from src.trading_logic.trade_simulator import TradeSimulator
+from src.trading_logic.trading_decision import TradingDecision
 
 
 class TradeExecutionManager:
@@ -26,6 +27,7 @@ class TradeExecutionManager:
         symbols (List[str]): List of stock symbols to process.
         strategy_manager (StrategyManager): Instance responsible for applying trading strategies.
         trade_simulator (TradeSimulator): Instance responsible for simulating trade executions.
+        decision_maker (TradingDecision): Component that determines BUY/SELL/HOLD signals.
     """
 
     def __init__(
@@ -33,7 +35,8 @@ class TradeExecutionManager:
         base_path: str,
         symbols_file: str,
         strategy_manager: StrategyManager,
-        trade_simulator: TradeSimulator
+        trade_simulator: TradeSimulator,
+        decision_maker: TradingDecision,
     ) -> None:
         """
         Initializes the TradeExecutionManager with data loading, strategy execution,
@@ -49,6 +52,7 @@ class TradeExecutionManager:
         # config.symbols: list = load_symbols(symbols_file)
         self.strategy_manager: StrategyManager = strategy_manager
         self.trade_simulator: TradeSimulator = trade_simulator
+        self.decision_maker: TradingDecision = decision_maker
 
         logger.info("TradeExecutionManager initialized with %d symbols.", len(config.symbols))
 
@@ -118,10 +122,12 @@ class TradeExecutionManager:
             raise KeyError(f"Missing required columns in data: {missing}")
 
         data_with_signals: pd.DataFrame = self.strategy_manager.apply_strategies(historical_data)
+        decisions = self.decision_maker.generate_decisions(data_with_signals)
+        data_with_signals['decision'] = decisions
 
         # Iterate over each row to execute trades
         for index, row in data_with_signals.iterrows():
-            signal: str = row['Majority_Vote_Strategy']
+            signal: str = row['decision']
             symbol: str = row['symbol']
             close_price: float = row['close']
             trade_date: pd.Timestamp = row['date']

--- a/src/trading_logic/trade_simulator.py
+++ b/src/trading_logic/trade_simulator.py
@@ -5,6 +5,8 @@ import os
 from loguru import logger
 from typing import Any, Dict, Optional, List
 
+from .transaction_tracker import TransactionTracker
+
 import pandas as pd
 from src import config
 
@@ -25,19 +27,22 @@ class TradeSimulator:
         trade_history (List[Dict[str, Any]]): List recording the history of executed trades.
     """
 
-    def __init__(self, initial_capital: float = 10000.0, transaction_cost: float = 20.0) -> None:
+    def __init__(self, initial_capital: float = 10000.0, transaction_cost: float = 20.0,
+                 tracker: Optional['TransactionTracker'] = None) -> None:
         """
         Initializes the TradeSimulator with capital and transaction cost settings.
 
         Args:
             initial_capital (float, optional): Starting capital for trading. Defaults to 10000.0.
             transaction_cost (float, optional): Fixed cost per transaction. Defaults to 20.0.
+            tracker (TransactionTracker, optional): Tracker to record executed transactions.
         """
         self.mode: str = config.trading_config.trade_mode
         self.initial_capital: float = initial_capital
         self.transaction_cost: float = transaction_cost
         self.positions: Dict[str, Dict[str, Any]] = self.load_positions() if self.mode == 'LIVE' else {}
         self.trade_history: List[Dict[str, Any]] = []
+        self.tracker = tracker
         self.positions_file_path = config.paths.positions_file_path
         logger.info("TradeSimulator initialized in '%s' mode with initial capital: %.2f and transaction cost: %.2f",
                      self.mode, self.initial_capital, self.transaction_cost)
@@ -140,6 +145,9 @@ class TradeSimulator:
         logger.debug("Opening %s position for %s at price %.2f on %s", position_type, symbol, price, date)
         shares: int = self.calculate_shares(price, position_type)
         cost: float = shares * price + self.transaction_cost
+        if self.tracker and not self.tracker.can_invest(symbol, shares * price):
+            logger.warning("Investment cap reached for %s", symbol)
+            return
 
         if self.initial_capital >= cost:
             self.initial_capital -= cost
@@ -311,6 +319,8 @@ class TradeSimulator:
             'holding_time': holding_time
         }
         self.trade_history.append(trade)
+        if self.tracker is not None:
+            self.tracker.record(action if action != 'CLOSE' else position_type.upper(), symbol, shares, price, pd.to_datetime(date))
         logger.debug("Recorded trade: %s", trade)
         # TODO: Store trade history in local storage or database for later analysis
 

--- a/src/trading_logic/trading_decision.py
+++ b/src/trading_logic/trading_decision.py
@@ -1,0 +1,29 @@
+"""Trading decision module."""
+from typing import Iterable
+import pandas as pd
+
+class TradingDecision:
+    """Simple decision engine based on model predictions and strategy signals."""
+
+    def __init__(self,
+                 buy_labels: Iterable[str] = ("High", "Medium High"),
+                 sell_labels: Iterable[str] = ("Medium Low", "Low")) -> None:
+        self.buy_labels = set(buy_labels)
+        self.sell_labels = set(sell_labels)
+
+    def decide_row(self, row: pd.Series) -> str:
+        """Return BUY, SELL or HOLD for a single row of data."""
+        strategy_signal = row.get("Majority_Vote_Strategy")
+        if strategy_signal in {"BUY", "SELL"}:
+            return strategy_signal
+
+        pred_label = row.get("prediction_pct_change")
+        if pred_label in self.buy_labels:
+            return "BUY"
+        if pred_label in self.sell_labels:
+            return "SELL"
+        return "HOLD"
+
+    def generate_decisions(self, df: pd.DataFrame) -> pd.Series:
+        """Generate decision column for a DataFrame."""
+        return df.apply(self.decide_row, axis=1)

--- a/src/trading_logic/transaction_tracker.py
+++ b/src/trading_logic/transaction_tracker.py
@@ -1,0 +1,40 @@
+"""Utility for tracking executed transactions."""
+from dataclasses import dataclass, field
+from typing import List, Dict
+from datetime import datetime
+
+@dataclass
+class Transaction:
+    action: str
+    symbol: str
+    qty: int
+    price: float
+    timestamp: datetime
+
+@dataclass
+class TransactionTracker:
+    balance: float = 0.0
+    transactions: List[Transaction] = field(default_factory=list)
+    positions: Dict[str, int] = field(default_factory=dict)
+
+    def record(self, action: str, symbol: str, qty: int, price: float, timestamp: datetime) -> None:
+        self.transactions.append(Transaction(action, symbol, qty, price, timestamp))
+        if action == "BUY":
+            self.balance -= qty * price
+            self.positions[symbol] = self.positions.get(symbol, 0) + qty
+        elif action == "SELL":
+            self.balance += qty * price
+            self.positions[symbol] = self.positions.get(symbol, 0) - qty
+
+    def invested_amount(self, symbol: str) -> float:
+        return abs(self.positions.get(symbol, 0)) * next((t.price for t in reversed(self.transactions)
+                                                          if t.symbol == symbol), 0)
+
+    def can_invest(self, symbol: str, cost: float) -> bool:
+        total_value = self.balance + sum(abs(p) * next((t.price for t in reversed(self.transactions)
+                                                        if t.symbol == s), 0)
+                                        for s, p in self.positions.items())
+        return (self.invested_amount(symbol) + cost) <= 0.1 * total_value
+
+    def current_position(self, symbol: str) -> int:
+        return self.positions.get(symbol, 0)


### PR DESCRIPTION
## Summary
- add `combine_all_symbols` setting for training
- modify backtest routine to support combined dataset training
- implement trading decision module
- connect decisions to trade execution manager
- add Fyers trade executor and transaction tracker utilities
- update trade simulator to use transaction tracker
- include new trading config in hydra

## Testing
- `pip install joblib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f47004c48328a37a83e204de4615