### PR TITLE
Add portfolio metrics and basic dashboard

### DIFF
--- a/src/metrics/performance_metrics.py
+++ b/src/metrics/performance_metrics.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import numpy as np
+from typing import List, Dict
+
+class PerformanceMetrics:
+    """Calculate portfolio performance metrics from trade history."""
+
+    def __init__(self, trade_history: List[Dict[str, any]], starting_capital: float, transaction_cost: float = 0.0) -> None:
+        self.trade_history = trade_history
+        self.starting_capital = starting_capital
+        self.transaction_cost = transaction_cost
+
+    def _history_df(self) -> pd.DataFrame:
+        df = pd.DataFrame(self.trade_history)
+        if not df.empty and 'date' in df.columns:
+            df['date'] = pd.to_datetime(df['date'])
+        return df
+
+    def roi(self) -> float:
+        df = self._history_df()
+        if df.empty:
+            return 0.0
+        final_balance = df.iloc[-1]['balance_after_trade']
+        return (final_balance - self.starting_capital) / self.starting_capital * 100
+
+    def equity_curve(self) -> pd.DataFrame:
+        df = self._history_df()
+        return df[['date', 'balance_after_trade']].sort_values('date') if not df.empty else df
+
+    def max_drawdown(self) -> float:
+        curve = self.equity_curve()
+        if curve.empty:
+            return 0.0
+        roll_max = curve['balance_after_trade'].cummax()
+        drawdown = (curve['balance_after_trade'] - roll_max) / roll_max
+        return drawdown.min() * 100
+
+    def win_rate(self) -> float:
+        df = self._history_df()
+        closes = df[df['action'] == 'CLOSE']
+        if closes.empty:
+            return 0.0
+        wins = closes[closes['net_profit_loss'] > 0]
+        return len(wins) / len(closes) * 100
+
+    def average_holding_period(self) -> float:
+        df = self._history_df()
+        closes = df[df['action'] == 'CLOSE']
+        if closes.empty:
+            return 0.0
+        return closes['holding_time'].mean()
+
+    def total_transaction_costs(self) -> float:
+        df = self._history_df()
+        return len(df) * self.transaction_cost
+
+    def diversification(self) -> int:
+        df = self._history_df()
+        return df['symbol'].nunique() if not df.empty else 0
+
+    def summary(self) -> Dict[str, float]:
+        return {
+            'ROI(%)': self.roi(),
+            'Sharpe': self.sharpe_ratio(),
+            'Max Drawdown(%)': self.max_drawdown(),
+            'Win Rate(%)': self.win_rate(),
+            'Avg Holding Period(days)': self.average_holding_period(),
+            'Transaction Costs': self.total_transaction_costs(),
+            'Symbols Traded': self.diversification(),
+        }
+
+    def sharpe_ratio(self, risk_free_rate: float = 0.0) -> float:
+        df = self.equity_curve()
+        if df.empty or len(df) < 2:
+            return 0.0
+        returns = df['balance_after_trade'].pct_change().dropna()
+        if returns.empty:
+            return 0.0
+        excess = returns - risk_free_rate/252
+        return np.sqrt(252) * excess.mean() / excess.std() if excess.std() != 0 else 0.0
+

--- a/src/trading_logic/trade_simulator.py
+++ b/src/trading_logic/trade_simulator.py
@@ -21,7 +21,8 @@ class TradeSimulator:
     
     Attributes:
         mode (str): Operational mode ('BACKTEST' or 'LIVE').
-        initial_capital (float): Starting capital for trading.
+        starting_capital (float): Starting capital for trading.
+        initial_capital (float): Current available capital.
         transaction_cost (float): Fixed cost per transaction.
         positions (Dict[str, Dict[str, Any]]): Dictionary tracking current positions per symbol.
         trade_history (List[Dict[str, Any]]): List recording the history of executed trades.
@@ -38,6 +39,8 @@ class TradeSimulator:
             tracker (TransactionTracker, optional): Tracker to record executed transactions.
         """
         self.mode: str = config.trading_config.trade_mode
+        # Track starting capital separately for performance metrics
+        self.starting_capital: float = initial_capital
         self.initial_capital: float = initial_capital
         self.transaction_cost: float = transaction_cost
         self.positions: Dict[str, Dict[str, Any]] = self.load_positions() if self.mode == 'LIVE' else {}
@@ -190,7 +193,7 @@ class TradeSimulator:
 
             net_profit_loss: float = profit_loss - self.transaction_cost
             self.initial_capital += net_profit_loss
-            self.record_trade('CLOSE', position['type'], symbol, price, position['shares'], date, position['entry_date'])
+            self.record_trade('CLOSE', position['type'], symbol, price, position['shares'], date, position['entry_date'], net_profit_loss)
             self.update_positions_file()
             logger.info("Closed %s position for %s: %d shares at %.2f on %s. P/L: %.2f",
                          position['type'].upper(), symbol, position['shares'], price, date, net_profit_loss)
@@ -294,7 +297,7 @@ class TradeSimulator:
             logger.warning("No open position found for symbol '%s' to check trailing stop loss.", symbol)
 
     def record_trade(self, action: str, position_type: str, symbol: str, price: float, shares: int,
-                    date: str, entry_date: Optional[str] = None) -> None:
+                    date: str, entry_date: Optional[str] = None, net_profit_loss: float = 0.0) -> None:
         """
         Records a trade action in the trade history.
 
@@ -316,7 +319,9 @@ class TradeSimulator:
             'shares': shares,
             'date': date,
             'balance_after_trade': self.initial_capital,
-            'holding_time': holding_time
+            'holding_time': holding_time,
+            'net_profit_loss': net_profit_loss,
+            'transaction_cost': self.transaction_cost,
         }
         self.trade_history.append(trade)
         if self.tracker is not None:

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1,0 +1,54 @@
+from flask import Flask, render_template_string
+import matplotlib.pyplot as plt
+import io
+import base64
+from src.trading_logic.trade_simulator import TradeSimulator
+from src.metrics.performance_metrics import PerformanceMetrics
+
+
+def create_app(simulator: TradeSimulator) -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/')
+    def dashboard():
+        metrics = PerformanceMetrics(simulator.trade_history,
+                                     simulator.starting_capital,
+                                     simulator.transaction_cost)
+        summary = metrics.summary()
+        curve = metrics.equity_curve()
+        img = ''
+        if not curve.empty:
+            fig, ax = plt.subplots()
+            ax.plot(curve['date'], curve['balance_after_trade'])
+            ax.set_title('Equity Curve')
+            ax.set_xlabel('Date')
+            ax.set_ylabel('Balance')
+            buf = io.BytesIO()
+            fig.tight_layout()
+            fig.savefig(buf, format='png')
+            plt.close(fig)
+            buf.seek(0)
+            img = base64.b64encode(buf.read()).decode('utf-8')
+
+        html = """
+        <html><head><title>Trading Dashboard</title></head><body>
+        <h1>Performance Summary</h1>
+        <table border='1'>
+        {% for key, value in summary.items() %}
+            <tr><th>{{ key }}</th><td>{{ '%.2f'|format(value) }}</td></tr>
+        {% endfor %}
+        </table>
+        <h2>Equity Curve</h2>
+        {% if img %}<img src="data:image/png;base64,{{img}}"/>{% endif %}
+        </body></html>
+        """
+        return render_template_string(html, summary=summary, img=img)
+
+    return app
+
+
+if __name__ == '__main__':
+    sim = TradeSimulator()
+    app = create_app(sim)
+    app.run(host='0.0.0.0', port=8050)
+


### PR DESCRIPTION
## Summary
- store starting capital in `TradeSimulator`
- track `net_profit_loss` and `transaction_cost` in trade history
- implement `PerformanceMetrics` helper
- add Flask dashboard UI showing metrics and equity curve

## Testing
- `pip install joblib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685701e8ad548328a09253a64ad5da21