### PR TITLE
Enhance ML pipeline

### DIFF
--- a/src/feature_engineering/custom_target_tranform.py
+++ b/src/feature_engineering/custom_target_tranform.py
@@ -5,7 +5,11 @@ import re
 import numpy as np
 import pandas as pd
 from functools import partial
+from joblib import Memory
 from src import config
+
+cache_dir = './pipeline_cache'
+memory = Memory(location=cache_dir, verbose=0)
 
 class TargetTransform:
     """
@@ -186,6 +190,7 @@ class TargetTransform:
 
         return atr.iloc[::-1]
 
+    @memory.cache
     def categorize_percent_change(self, data: pd.DataFrame, run_id: str) -> pd.Series:
         """
         Computes the largest absolute percent change (either maximum or minimum) within a specified forward window size 
@@ -231,6 +236,7 @@ class TargetTransform:
 
         return df, categories
 
+    @memory.cache
     def categorize_atr(self, data: pd.DataFrame, run_id: str) -> pd.Series:
         """
         Calculates the ATR over a specified window size and categorizes the ATR values.

--- a/src/pipelines/base_pipeline.py
+++ b/src/pipelines/base_pipeline.py
@@ -1,20 +1,17 @@
 # src/pipelines/base_pipeline.py
 
-from typing import Any, Dict, Union, List, Optional, Tuple
-import joblib
+from typing import Any, Dict, List, Optional, Tuple
 import os
 import pandas as pd
 from datetime import datetime
 from loguru import logger
-from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.model_selection import train_test_split
+from sklearn.impute import SimpleImputer
 from imblearn.pipeline import Pipeline
 from sklearn.base import clone
-import pandas as pd
+from joblib import Parallel, delayed
 import mlflow
 import mlflow.sklearn
-from imblearn.over_sampling import SMOTE
-from sklearn.metrics import f1_score, accuracy_score, precision_score, recall_score
-from src.config.vars import CLOSE
 from joblib import Memory  # NEW: Import Memory for caching
 from src import config, pp
 from src.feature_engineering.custom_target_tranform import TargetTransform
@@ -141,11 +138,22 @@ class MLPipelineBase:
         drop_cols = [col for col in ['expiry', 'symbol','open_interest_flag'] if col in df.columns]
         df = df.drop(columns=drop_cols, errors='ignore')
 
-        # Remove rows with any NaN values
-        rows_to_drop = df.isna().any(axis=1)
+        # Remove rows where target is NaN
+        rows_to_drop = target.isna()
         df, target = df[~rows_to_drop], target[~rows_to_drop]
+
         df = df.infer_objects()
         df = df.replace({True: 1, False: 0})
+
+        # Impute missing values instead of dropping rows
+        numeric_cols = df.select_dtypes(include=['number']).columns
+        cat_cols = df.select_dtypes(exclude=['number']).columns
+        if len(numeric_cols) > 0:
+            num_imputer = SimpleImputer(strategy='median')
+            df[numeric_cols] = num_imputer.fit_transform(df[numeric_cols])
+        if len(cat_cols) > 0:
+            cat_imputer = SimpleImputer(strategy='most_frequent')
+            df[cat_cols] = cat_imputer.fit_transform(df[cat_cols])
         
         
         # cat_cols = list(getattr(config.columns, 'cat_cols', []))
@@ -207,60 +215,52 @@ class MLPipelineBase:
         
         
         for pipeline in self.pipelines:
-            for run_id in run_ids:
-                for target in config.model_settings.model_targets:
-                    # try:
-                    #self.model = self.define_model(pipeline)
-                    logger.info(f"Training model for {symbol} {run_id} {target} with config: {pp.pformat(pipeline.params)}")
-                    with mlflow.start_run(run_name=f"{symbol}_{run_id}_{target}_{self.model_id}"):
-                        mlflow.set_tag("mode", self.mode)
-                        mlflow.set_tag("model_id", self.model_id)
-                        # mlflow.log_params(pipeline.params) 
-                        mlflow.log_param("symbol", symbol)
-                        mlflow.log_param("run_id", run_id)
-                        mlflow.log_param("target", target)
+            Parallel(n_jobs=-1)(
+                delayed(self._train_single)(pipeline, run_id, target, X, symbol)
+                for run_id in run_ids
+                for target in config.model_settings.model_targets
+            )
 
-                        X_train, X_test, y_train, y_test = self.transform_and_split(X, target, run_id)
+    def _train_single(self, pipeline: CustomModelPipeline, run_id: str, target: str, X: pd.DataFrame, symbol: str) -> None:
+        logger.info(
+            f"Training model for {symbol} {run_id} {target} with config: {pp.pformat(pipeline.params)}"
+        )
+        with mlflow.start_run(run_name=f"{symbol}_{run_id}_{target}_{self.model_id}"):
+            mlflow.set_tag("mode", self.mode)
+            mlflow.set_tag("model_id", self.model_id)
+            mlflow.log_param("symbol", symbol)
+            mlflow.log_param("run_id", run_id)
+            mlflow.log_param("target", target)
 
-                        if y_train is None:
-                            logger.warning(f"Target {target} could not be prepared for {symbol} {run_id}")
-                            continue
+            X_train, X_test, y_train, y_test = self.transform_and_split(X, target, run_id)
 
-                        if pipeline.model is None:
-                            raise ValueError("Model has not been defined. Call setup() before running.")
-                        
-                        # Fit the model
-                        pipeline.model.fit(X_train, y_train)
+            if y_train is None:
+                logger.warning(f"Target {target} could not be prepared for {symbol} {run_id}")
+                return
 
-                        # Log best parameters
-                        mlflow.log_params(pipeline.model.best_params_)
+            if pipeline.model is None:
+                raise ValueError("Model has not been defined. Call setup() before running.")
 
-                        # Predict on training data
-                        y_pred = pipeline.model.predict(X_test)
+            pipeline.model.fit(X_train, y_train)
+            mlflow.log_params(pipeline.model.best_params_)
+            y_pred = pipeline.model.predict(X_test)
 
-                        # Log performance metrics and artifacts
-                        log_model_performance(y_test, y_pred, pipeline.model.best_estimator_)
+            log_model_performance(y_test, y_pred, pipeline.model.best_estimator_, X_test)
 
-                        # Log the model
-                        registered_model_name = f"{symbol}_{run_id}_{target}"
-                        mlflow.sklearn.log_model(
-                            sk_model=pipeline.model.best_estimator_,
-                            artifact_path="model",
-                            registered_model_name=registered_model_name
-                        )
+            registered_model_name = f"{symbol}_{run_id}_{target}"
+            mlflow.sklearn.log_model(
+                sk_model=pipeline.model.best_estimator_,
+                artifact_path="model",
+                registered_model_name=registered_model_name,
+            )
 
-                        # Store the best estimator
-                        if symbol not in self.best_model_dict:
-                            self.best_model_dict[symbol] = {}
-                        if run_id not in self.best_model_dict[symbol]:
-                            self.best_model_dict[symbol][run_id] = {}
-                        self.best_model_dict[symbol][run_id][target] = clone(pipeline.model.best_estimator_)
-                    # except Exception as e:
-                    #     mlflow.log_param("error", str(e))
-                    #     logger.error(f"Error encountered while training: {symbol}_{run_id}_{target}_{self.model_id} \n {str(e)}")
-                    #     raise e
+            if symbol not in self.best_model_dict:
+                self.best_model_dict[symbol] = {}
+            if run_id not in self.best_model_dict[symbol]:
+                self.best_model_dict[symbol][run_id] = {}
+            self.best_model_dict[symbol][run_id][target] = clone(pipeline.model.best_estimator_)
 
-    def predict(self, X: pd.DataFrame, symbol: str) -> None:
+    def predict(self, X: pd.DataFrame, symbol: str) -> pd.DataFrame:
         """
         Makes predictions using the pre-loaded models in LIVE mode.
 
@@ -269,13 +269,14 @@ class MLPipelineBase:
             symbol (str): The stock symbol.
         """
         run_ids = config.model_settings.run_ids
+        targets = config.model_settings.model_targets
         model_fit_dict = self.best_model_dict.get(symbol, {})
         if not model_fit_dict:
             logger.warning(f"No models available for symbol '{symbol}' in LIVE mode.")
-            return
+            return X
 
         for run_id in run_ids:
-            for target in ['pct_change', 'atr']:
+            for target in targets:
                 model = model_fit_dict.get(run_id, {}).get(target, None)
                 if model is None:
                     logger.warning(f"No model found for {symbol} {run_id} {target}")
@@ -289,8 +290,15 @@ class MLPipelineBase:
                     prediction = model.predict(X)
                     X.loc[:, f'prediction_{run_id}_{target}'] = prediction
 
+                    if hasattr(model, "predict_proba"):
+                        probas = model.predict_proba(X)
+                        for idx, class_label in enumerate(model.classes_):
+                            X.loc[:, f'prob_{run_id}_{target}_{class_label}'] = probas[:, idx]
+
                     # Log prediction (optional)
                     mlflow.log_metric("prediction", prediction[0])  # Logging first prediction as an example
+
+        return X
 
     def prepare_input_and_target(self, X: pd.DataFrame, target: str, run_id: str) -> Optional[pd.Series]:
         """

--- a/src/pipelines/custom_pipelines.py
+++ b/src/pipelines/custom_pipelines.py
@@ -1,8 +1,8 @@
 import pandas as pd
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 from imblearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import RandomizedSearchCV
 from joblib import Memory  # Add this import
 
 from src import config
@@ -144,23 +144,25 @@ class CustomModelPipeline():
         # Define the pipeline with the configured steps
         self.pipeline = Pipeline(self.steps)
 
-    def define_model(self,memory: Memory = None) -> GridSearchCV:
+    def define_model(self, memory: Memory = None) -> RandomizedSearchCV:
         """
-        Defines the machine learning model using GridSearchCV for hyperparameter tuning.
+        Defines the machine learning model using RandomizedSearchCV for hyperparameter tuning.
 
         Returns:
-            GridSearchCV: An instance of GridSearchCV configured with the pipeline and parameter grid.
+            RandomizedSearchCV: Configured search instance.
         """
         self.define_pipeline()
         if memory:
             self.pipeline.memory = memory
 
-        self.model = GridSearchCV(
+        self.model = RandomizedSearchCV(
             self.pipeline,
-            param_grid=self.params,
+            param_distributions=self.params,
+            n_iter=20,
             scoring='accuracy',
             n_jobs=4,
             cv=3,
+            random_state=42,
             verbose=1,
             return_train_score=True,
             error_score='raise'

--- a/src/utils/mlflow_utils.py
+++ b/src/utils/mlflow_utils.py
@@ -2,14 +2,18 @@
 
 import mlflow
 import mlflow.sklearn
-from sklearn.metrics import (f1_score, accuracy_score, 
-                             precision_score, recall_score, 
-                             confusion_matrix)
-import pandas as pd
+from sklearn.metrics import (
+    f1_score,
+    accuracy_score,
+    precision_score,
+    recall_score,
+    confusion_matrix,
+    roc_auc_score,
+)
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-def log_model_performance(y_true, y_pred, model):
+def log_model_performance(y_true, y_pred, model, X_test=None):
     """
     Logs model performance metrics, confusion matrix, and feature importance to MLflow.
 
@@ -25,11 +29,24 @@ def log_model_performance(y_true, y_pred, model):
     precision = precision_score(y_true, y_pred, average='weighted', zero_division=0)
     recall = recall_score(y_true, y_pred, average='weighted', zero_division=0)
 
+    roc_auc = None
+    if X_test is not None and hasattr(model, "predict_proba"):
+        try:
+            y_proba = model.predict_proba(X_test)
+            roc_auc = roc_auc_score(y_true, y_proba, multi_class='ovr')
+        except Exception:
+            roc_auc = None
+
     # Log metrics
     mlflow.log_metric("f1_score", f1)
     mlflow.log_metric("accuracy", accuracy)
     mlflow.log_metric("precision", precision)
     mlflow.log_metric("recall", recall)
+    if roc_auc is not None:
+        mlflow.log_metric("roc_auc", roc_auc)
+    if hasattr(model, "cv_results_"):
+        cv_score = model.cv_results_["mean_test_score"][model.best_index_]
+        mlflow.log_metric("cv_mean_score", cv_score)
 
     # Confusion matrix
     cm = confusion_matrix(y_true, y_pred)


### PR DESCRIPTION
## Summary
- add joblib caching for target transforms
- improve data cleaning with imputation
- parallelize training step
- log more metrics including ROC-AUC and CV score
- switch to RandomizedSearchCV
- enrich live predictions with probability columns

## Testing
- `ruff check src/feature_engineering/custom_target_tranform.py src/pipelines/base_pipeline.py src/pipelines/custom_pipelines.py src/utils/mlflow_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685709fca7988328acb70abe6e66c541