### PR TITLE
Fix strategy execution and add basic caching

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,14 +79,12 @@ class MarketAnalysisApp:
             raise
     
     def execute_strategies(self, indicators_data: dict, predictions: dict) -> None:
-        """Execute trading strategies combining indicators and model predictions."""
+        """Execute trading strategies combining indicators and predictions."""
         try:
-            # Merge technical indicators with model predictions
             enhanced_data = {
                 **indicators_data,
-                'model_predictions': predictions
-            } 
-            
+                "model_predictions": predictions,
+            }
             strategy_decisions = self.strategy_module.execute_technical_strategy(enhanced_data)
             self._execute_trades_based_on_decisions(strategy_decisions)
         except Exception as e:
@@ -99,18 +97,12 @@ class MarketAnalysisApp:
         self.ticker_data_handler.register_callback(
                 self.indicators.get_stock_indicators)
         # self.indicators.register_callback(self.execute_strategies)
-    
-    def execute_strategies(self, indicators_data):
-        """
-        Execute trading strategies based on the indicators data.
-        """
-        try:
-            strategy_decisions = self.strategy_module.execute_technical_strategy(
-                indicators_data)
-            # Process the strategy decisions further as needed
-        except Exception as e:
-            logger.error("Strategy execution failed")
-            raise
+
+    def _execute_trades_based_on_decisions(self, decisions: dict) -> None:
+        """Handle trade execution based on strategy decisions."""
+        for symbol, decision_data in decisions.items():
+            majority_decision = decision_data.get("Majority_Vote_Strategy")
+            logger.info(f"{symbol}: {majority_decision}")
 
 
     def _schedule_job(self, func: Callable, job_id: str) -> None:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,21 +1,19 @@
 import hydra
-from omegaconf import DictConfig, OmegaConf
-from pathlib import Path
-from loguru import logger
-import sys,os
-from typing import Optional
+from omegaconf import DictConfig
+from functools import lru_cache
+
+"""Configuration loading utilities."""
 
 
 
+@lru_cache(maxsize=1)
 def get_config() -> DictConfig:
-    # global _config
-    # If the configuration is not already loaded, initialize and compose it
-    # if _config is None:
+    """Load and cache the Hydra configuration once."""
     try:
         with hydra.initialize(config_path="."):
-            _config = hydra.compose(config_name="config.yaml") #version_base="1.1"
+            _config = hydra.compose(config_name="config.yaml")
         return _config
-    except Exception as e:
-        raise f"Error loading configuration: {e}"
+    except Exception as e:  # pragma: no cover - configuration errors are fatal
+        raise RuntimeError(f"Error loading configuration: {e}")
 
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -5,13 +5,15 @@ import pandas as pd
 import time
 import pytz
 from selenium.webdriver.chrome.options import Options
-from functools import partial
+from functools import partial, lru_cache
 from typing import List
 import datetime
 import yaml
 
 
-def load_config(filename):
+@lru_cache(maxsize=None)
+def load_config(filename: str):
+    """Load YAML configuration from ``filename`` and cache the result."""
     with open(filename, 'r') as file:
         return yaml.safe_load(file)
 
@@ -52,6 +54,7 @@ def get_chrome_options() -> Options:
     return options
 
  
+@lru_cache(maxsize=None)
 def load_symbols(symbols_file: str) -> List[str]:
     """
     Loads stock symbols from a specified file, one per line.


### PR DESCRIPTION
## Summary
- fix MarketAnalysisApp by removing duplicate method and logging trade decisions
- cache configuration loading and symbol lookup functions
- raise proper RuntimeError if configuration fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_685800d8cdac8328b071c8dc52b3e5c0